### PR TITLE
Added initFromXMLFilePath: to open with a full path

### DIFF
--- a/RaptureXML/RXMLElement.h
+++ b/RaptureXML/RXMLElement.h
@@ -42,6 +42,7 @@
 - (id)initFromXMLString:(NSString *)xmlString encoding:(NSStringEncoding)encoding;
 - (id)initFromXMLFile:(NSString *)filename;
 - (id)initFromXMLFile:(NSString *)filename fileExtension:(NSString*)extension;
+- (id)initFromXMLFilePath:(NSString *)fullPath;
 - (id)initFromURL:(NSURL *)url __attribute__((deprecated));
 - (id)initFromXMLData:(NSData *)data;
 - (id)initFromXMLNode:(xmlNodePtr)node;

--- a/RaptureXML/RXMLElement.m
+++ b/RaptureXML/RXMLElement.m
@@ -45,77 +45,25 @@
 @implementation RXMLElement
 
 - (id)initFromXMLString:(NSString *)xmlString encoding:(NSStringEncoding)encoding {
-    if ((self = [super init])) {
-        NSData *data = [xmlString dataUsingEncoding:encoding];
+    return [self initFromXMLData:[xmlString dataUsingEncoding:encoding]];
+}
 
-        doc_ = xmlReadMemory([data bytes], [data length], "", nil, XML_PARSE_RECOVER);
-        
-        if ([self isValid]) {
-            node_ = xmlDocGetRootElement(doc_);
-            
-            if (!node_) {
-                xmlFreeDoc(doc_); doc_ = nil;
-            }
-        }
-    }
-    
-    return self;    
+- (id)initFromXMLFilePath:(NSString *)fullPath {
+    return [self initFromXMLData:[NSData dataWithContentsOfFile:fullPath]];
 }
 
 - (id)initFromXMLFile:(NSString *)filename {
-    if ((self = [super init])) {
-        NSString *fullPath = [[[NSBundle bundleForClass:self.class] bundlePath] stringByAppendingPathComponent:filename];
-        NSData *data = [NSData dataWithContentsOfFile:fullPath];
-
-        doc_ = xmlReadMemory([data bytes], [data length], "", nil, XML_PARSE_RECOVER);
-        
-        if ([self isValid]) {
-            node_ = xmlDocGetRootElement(doc_);
-            
-            if (!node_) {
-                xmlFreeDoc(doc_); doc_ = nil;
-            }
-        }
-    }
-    
-    return self;    
+    NSString *fullPath = [[[NSBundle bundleForClass:self.class] bundlePath] stringByAppendingPathComponent:filename];
+    return [self initFromXMLFilePath:fullPath];
 }
 
 - (id)initFromXMLFile:(NSString *)filename fileExtension:(NSString *)extension {
-    if ((self = [super init])) {
-        NSString *fullPath = [[NSBundle bundleForClass:[self class]] pathForResource:filename ofType:extension];
-        NSData *data = [NSData dataWithContentsOfFile:fullPath];
-        
-        doc_ = xmlReadMemory([data bytes], [data length], "", nil, XML_PARSE_RECOVER);
-        
-        if ([self isValid]) {
-            node_ = xmlDocGetRootElement(doc_);
-            
-            if (!node_) {
-                xmlFreeDoc(doc_); doc_ = nil;
-            }
-        }
-    }
-    
-    return self;    
+    NSString *fullPath = [[NSBundle bundleForClass:[self class]] pathForResource:filename ofType:extension];
+    return [self initFromXMLData:[NSData dataWithContentsOfFile:fullPath]];
 }
 
 - (id)initFromURL:(NSURL *)url {
-    if ((self = [super init])) {
-        NSData *data = [NSData dataWithContentsOfURL:url];
-        
-        doc_ = xmlReadMemory([data bytes], [data length], "", nil, XML_PARSE_RECOVER);
-        
-        if ([self isValid]) {
-            node_ = xmlDocGetRootElement(doc_);
-            
-            if (!node_) {
-                xmlFreeDoc(doc_); doc_ = nil;
-            }
-        }
-    }
-    
-    return self;    
+    return [self initFromXMLData:[NSData dataWithContentsOfURL:url]];
 }
 
 - (id)initFromXMLData:(NSData *)data {


### PR DESCRIPTION
Reuse initWithXMLData: method to reduce code duplication
Add initFromXMLFilePath: to give a full path rather than a bundle path
