### PR TITLE
Add + (id)elementFromXMLFilePath:(NSString *)fullPath 

### DIFF
--- a/RaptureXML/RXMLElement.h
+++ b/RaptureXML/RXMLElement.h
@@ -58,6 +58,7 @@
 + (id)elementFromXMLString:(NSString *)xmlString encoding:(NSStringEncoding)encoding;
 + (id)elementFromXMLFile:(NSString *)filename;
 + (id)elementFromXMLFilename:(NSString *)filename fileExtension:(NSString *)extension;
++ (id)elementFromXMLFilePath:(NSString *)fullPath;
 + (id)elementFromURL:(NSURL *)url __attribute__((deprecated));
 + (id)elementFromXMLData:(NSData *)data;
 + (id)elementFromXMLDoc:(RXMLDocHolder *)doc node:(xmlNodePtr)node;

--- a/RaptureXML/RXMLElement.m
+++ b/RaptureXML/RXMLElement.m
@@ -115,6 +115,10 @@
     return [[RXMLElement alloc] initFromXMLString:attributeXML_ encoding:encoding];    
 }
 
++ (id)elementFromXMLFilePath:(NSString *)fullPath {
+    return [[RXMLElement alloc] initFromXMLFilePath:fullPath];
+}
+
 + (id)elementFromXMLFile:(NSString *)filename {
     return [[RXMLElement alloc] initFromXMLFile:filename];    
 }


### PR DESCRIPTION
I used accidentally elementFromXMLFile:, because I expected elementFromXMLFilePath:, after seeing initFromXMLFilePath:. 
To make it more complete, add elementFromXMLFilePath:.
