### PR TITLE
Fixed crash when parsing some xml

### DIFF
--- a/RaptureXML/RXMLElement.m
+++ b/RaptureXML/RXMLElement.m
@@ -309,6 +309,8 @@
 - (RXMLElement *)child:(NSString *)tag {
     NSArray *components = [tag componentsSeparatedByString:@"."];
     xmlNodePtr cur = node_;
+	
+	if (!cur) return nil;
     
     // navigate down
     for (NSString *itag in components) {


### PR DESCRIPTION
This should fix a crash I had with some bad xml response (not really invalid xml, but xml with some server errors inside).
