### PR TITLE
Updated for Dynamic Frameworks in iOS 8...

### DIFF
--- a/RaptureXML/RXMLElement.m
+++ b/RaptureXML/RXMLElement.m
@@ -63,12 +63,12 @@
 }
 
 - (id)initFromXMLFile:(NSString *)filename {
-    NSString *fullPath = [[[NSBundle bundleForClass:self.class] bundlePath] stringByAppendingPathComponent:filename];
+    NSString *fullPath = [[[NSBundle mainBundle] bundlePath] stringByAppendingPathComponent:filename];
     return [self initFromXMLFilePath:fullPath];
 }
 
 - (id)initFromXMLFile:(NSString *)filename fileExtension:(NSString *)extension {
-    NSString *fullPath = [[NSBundle bundleForClass:[self class]] pathForResource:filename ofType:extension];
+    NSString *fullPath = [[NSBundle mainBundle] pathForResource:filename ofType:extension];
     return [self initFromXMLData:[NSData dataWithContentsOfFile:fullPath]];
 }
 
@@ -107,12 +107,12 @@
 }
 
 - (id)initFromHTMLFile:(NSString *)filename {
-    NSString *fullPath = [[[NSBundle bundleForClass:self.class] bundlePath] stringByAppendingPathComponent:filename];
+    NSString *fullPath = [[[NSBundle mainBundle] bundlePath] stringByAppendingPathComponent:filename];
     return [self initFromHTMLData:[NSData dataWithContentsOfFile:fullPath]];
 }
 
 - (id)initFromHTMLFile:(NSString *)filename fileExtension:(NSString*)extension {
-    NSString *fullPath = [[NSBundle bundleForClass:[self class]] pathForResource:filename ofType:extension];
+    NSString *fullPath = [[NSBundle mainBundle] pathForResource:filename ofType:extension];
     return [self initFromHTMLData:[NSData dataWithContentsOfFile:fullPath]];
 }
 


### PR DESCRIPTION
Changed all references to [NSBundle bundleForClass:self.class] to [NSBundle mainBundle] so that references to resources outside of the scope of RaptureXML can be used. This is done when including this as a pod using Cocoapods, using `use_frameworks!` in your Podfile and necessary when linking against Swift libraries.
